### PR TITLE
Add thumbnail-of-pptx skill

### DIFF
--- a/.agents/skills/thumbnail-of-pptx/SKILL.md
+++ b/.agents/skills/thumbnail-of-pptx/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: thumbnail-of-pptx
+description: >-
+  Capture a thumbnail image of a slide from a OneDrive/Office presentation link.
+  Opens the PowerPoint web viewer in a headless browser and screenshots the
+  slide canvas, producing a clean 16:9 image with no viewer chrome. Works even
+  when the PPTX is not downloadable (e.g. personal OneDrive shares), since it
+  screenshots the rendered slide rather than converting the file.
+  USE FOR: make a thumbnail from a PPTX, screenshot a slide, title-slide image,
+  OneDrive slide thumbnail, talk thumbnail from slides.
+argument-hint: <url> <output_path>
+---
+
+# Thumbnail of a PPTX slide
+
+Run the [thumbnail_of_pptx.py](./thumbnail_of_pptx.py) script to capture a slide
+thumbnail from a OneDrive/Office presentation link:
+
+```bash
+uv run .agents/skills/thumbnail-of-pptx/thumbnail_of_pptx.py <url> <output_path>
+```
+
+## Arguments
+
+- `url` (required): A OneDrive sharing link, or an `aka.ms` short link that
+  redirects to one (e.g. `https://aka.ms/my-talk-slides`). The link must open
+  the Office Online / PowerPoint **web viewer**.
+- `output_path` (required): Path to write the PNG thumbnail (e.g.
+  `thumbnail.png`). Parent directories are created if needed.
+- `--slide N` (optional): 1-based slide number to capture. Defaults to `1`, the
+  title slide.
+- `--scale N` (optional): Device scale factor for a crisper image. Defaults to
+  `2`.
+- `--wait MS` (optional): Milliseconds to wait for the slide to render before
+  screenshotting. Defaults to `9000`. Increase for large decks or slow networks.
+
+## Outputs
+
+A single PNG image of the requested slide, cropped to the slide canvas (roughly
+16:9, no PowerPoint viewer UI).
+
+## Prerequisites
+
+Playwright browsers must be installed:
+
+```bash
+uv run playwright install chromium
+```
+
+## How it works
+
+1. Launches headless Chromium and navigates to the URL (following `aka.ms`
+   redirects to the real OneDrive viewer).
+2. Waits for the network to go idle, then waits a fixed delay for the Office
+   Online viewer to stream in and paint the slide.
+3. Locates the viewer iframe (named `wacIframe`, with a fallback that finds any
+   frame containing a `<canvas>`).
+4. Optionally advances to slide `N` by focusing the canvas and pressing the
+   right-arrow key.
+5. Element-screenshots the slide `<canvas>` so the output contains only the
+   slide, not the surrounding viewer chrome.
+
+## Notes
+
+- This is complementary to **fetch-slides**: use `fetch-slides` when you need the
+  full deck as a PDF (requires LibreOffice for PPTX), and this skill when you
+  just want a lightweight thumbnail image of one slide and the file may not be
+  downloadable.
+- Because it relies on the public web viewer, the sharing link must be viewable
+  by anyone with the link.

--- a/.agents/skills/thumbnail-of-pptx/thumbnail_of_pptx.py
+++ b/.agents/skills/thumbnail-of-pptx/thumbnail_of_pptx.py
@@ -62,35 +62,37 @@ def capture_thumbnail(
 
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=True)
-        page = browser.new_page(
-            viewport={"width": 1600, "height": 1000},
-            device_scale_factor=scale,
-        )
-        logger.info("Opening %s", url)
-        # aka.ms short links redirect to the real OneDrive viewer URL; Playwright
-        # follows the redirects for us.
-        page.goto(url, wait_until="networkidle", timeout=90000)
-        # The viewer streams the slide in after load; give it time to paint.
-        page.wait_for_timeout(wait_ms)
+        try:
+            page = browser.new_page(
+                viewport={"width": 1600, "height": 1000},
+                device_scale_factor=scale,
+            )
+            logger.info("Opening %s", url)
+            # aka.ms short links redirect to the real OneDrive viewer URL;
+            # Playwright follows the redirects for us.
+            page.goto(url, wait_until="networkidle", timeout=90000)
+            # The viewer streams the slide in after load; give it time to paint.
+            page.wait_for_timeout(wait_ms)
 
-        frame = find_viewer_frame(page)
+            frame = find_viewer_frame(page)
 
-        if slide > 1:
-            logger.info("Advancing to slide %d", slide)
+            if slide > 1:
+                logger.info("Advancing to slide %d", slide)
+                canvas = frame.query_selector("canvas")
+                if canvas:
+                    canvas.click()
+                for _ in range(slide - 1):
+                    frame.press("body", "ArrowRight")
+                    page.wait_for_timeout(1200)
+
             canvas = frame.query_selector("canvas")
-            if canvas:
-                canvas.click()
-            for _ in range(slide - 1):
-                frame.press("body", "ArrowRight")
-                page.wait_for_timeout(1200)
+            if canvas is None:
+                raise RuntimeError("No slide canvas found in the viewer frame.")
 
-        canvas = frame.query_selector("canvas")
-        if canvas is None:
+            canvas.screenshot(path=str(output_path))
+        finally:
+            # Always close Chromium, even if navigation or rendering failed.
             browser.close()
-            raise RuntimeError("No slide canvas found in the viewer frame.")
-
-        canvas.screenshot(path=str(output_path))
-        browser.close()
 
     logger.info("Saved thumbnail to %s", output_path)
 

--- a/.agents/skills/thumbnail-of-pptx/thumbnail_of_pptx.py
+++ b/.agents/skills/thumbnail-of-pptx/thumbnail_of_pptx.py
@@ -1,0 +1,144 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "playwright",
+# ]
+# ///
+"""Capture a slide thumbnail image from a OneDrive/Office web-viewer presentation.
+
+Given a OneDrive sharing link (or an aka.ms short link that redirects to one),
+this opens the PowerPoint web viewer with a headless browser, waits for the
+slide to render, and element-screenshots the slide canvas. The result is a
+clean 16:9 image of the slide with no viewer chrome -- ideal for a talk
+thumbnail.
+
+Unlike fetch-slides, this needs no LibreOffice: it screenshots the slide as
+rendered by the Office Online viewer, so it works even when the PPTX itself is
+not downloadable (e.g. personal OneDrive shares).
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from playwright.sync_api import Frame, sync_playwright
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+# The Office Online viewer renders the deck inside an iframe named "wacIframe".
+VIEWER_FRAME_NAME = "wacIframe"
+
+
+def find_viewer_frame(page) -> Frame:
+    """Return the Office web-viewer iframe that contains the slide canvas."""
+    # Preferred: the well-known frame name used by the Office Online viewer.
+    for frame in page.frames:
+        if frame.name == VIEWER_FRAME_NAME:
+            return frame
+    # Fallback: any frame that actually holds a <canvas> element.
+    for frame in page.frames:
+        try:
+            if frame.query_selector("canvas"):
+                return frame
+        except Exception:
+            continue
+    raise RuntimeError(
+        "Could not find the slide viewer iframe. Is this a OneDrive/Office "
+        "presentation sharing link?"
+    )
+
+
+def capture_thumbnail(
+    url: str,
+    output_path: Path,
+    slide: int = 1,
+    scale: int = 2,
+    wait_ms: int = 9000,
+) -> None:
+    """Open the viewer, advance to the requested slide, screenshot the canvas."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page(
+            viewport={"width": 1600, "height": 1000},
+            device_scale_factor=scale,
+        )
+        logger.info("Opening %s", url)
+        # aka.ms short links redirect to the real OneDrive viewer URL; Playwright
+        # follows the redirects for us.
+        page.goto(url, wait_until="networkidle", timeout=90000)
+        # The viewer streams the slide in after load; give it time to paint.
+        page.wait_for_timeout(wait_ms)
+
+        frame = find_viewer_frame(page)
+
+        if slide > 1:
+            logger.info("Advancing to slide %d", slide)
+            canvas = frame.query_selector("canvas")
+            if canvas:
+                canvas.click()
+            for _ in range(slide - 1):
+                frame.press("body", "ArrowRight")
+                page.wait_for_timeout(1200)
+
+        canvas = frame.query_selector("canvas")
+        if canvas is None:
+            browser.close()
+            raise RuntimeError("No slide canvas found in the viewer frame.")
+
+        canvas.screenshot(path=str(output_path))
+        browser.close()
+
+    logger.info("Saved thumbnail to %s", output_path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Capture a slide thumbnail from a OneDrive/Office presentation link."
+    )
+    parser.add_argument(
+        "url",
+        help="OneDrive sharing link or aka.ms short link to the presentation.",
+    )
+    parser.add_argument(
+        "output_path",
+        help="Path to write the PNG thumbnail (e.g. thumbnail.png).",
+    )
+    parser.add_argument(
+        "--slide",
+        type=int,
+        default=1,
+        help="1-based slide number to capture (default: 1, the title slide).",
+    )
+    parser.add_argument(
+        "--scale",
+        type=int,
+        default=2,
+        help="Device scale factor for a crisper image (default: 2).",
+    )
+    parser.add_argument(
+        "--wait",
+        type=int,
+        default=9000,
+        help="Milliseconds to wait for the slide to render (default: 9000).",
+    )
+    args = parser.parse_args()
+
+    try:
+        capture_thumbnail(
+            url=args.url,
+            output_path=Path(args.output_path),
+            slide=args.slide,
+            scale=args.scale,
+            wait_ms=args.wait,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Error: %s", exc)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Converts a PDF file into individual PNG images (one per slide) using poppler's `
 
 **Use when:** converting PDF slides to images, splitting a PDF into per-slide PNGs.
 
+### 🖼️ thumbnail-of-pptx
+
+Captures a thumbnail image of a slide from a OneDrive/Office presentation link by opening the PowerPoint web viewer in a headless browser and screenshotting the slide canvas. Works even when the PPTX itself is not downloadable.
+
+**Use when:** making a thumbnail from a PPTX, screenshotting a title slide, or generating a talk thumbnail from OneDrive-hosted slides.
+
 ### 📝 extract-slide-text
 
 Extracts text from each page of a PDF into a structured markdown file using `pdftotext`.
@@ -106,6 +112,7 @@ npx skills add pamelafox/presentation-skills/make-revealjs-presentation
 npx skills add pamelafox/presentation-skills/review-presentation
 npx skills add pamelafox/presentation-skills/capture-video-frames
 npx skills add pamelafox/presentation-skills/convert-slides-to-images
+npx skills add pamelafox/presentation-skills/thumbnail-of-pptx
 npx skills add pamelafox/presentation-skills/extract-slide-text
 npx skills add pamelafox/presentation-skills/extract-transcript
 npx skills add pamelafox/presentation-skills/fetch-slides
@@ -132,6 +139,7 @@ gh skill install pamelafox/presentation-skills make-revealjs-presentation
 gh skill install pamelafox/presentation-skills review-presentation
 gh skill install pamelafox/presentation-skills capture-video-frames
 gh skill install pamelafox/presentation-skills convert-slides-to-images
+gh skill install pamelafox/presentation-skills thumbnail-of-pptx
 gh skill install pamelafox/presentation-skills extract-slide-text
 gh skill install pamelafox/presentation-skills extract-transcript
 gh skill install pamelafox/presentation-skills fetch-slides


### PR DESCRIPTION
Adds a new agent skill, **thumbnail-of-pptx**, that captures a thumbnail image of a slide from a OneDrive/Office presentation link.

## Why

When adding talks to my site, I wanted a thumbnail for each one. The decks live on personal OneDrive and aren't downloadable (anonymous download returns 401) and there's no LibreOffice locally, so `fetch-slides` couldn't help. But the **Office Online web viewer** renders the slides publicly — so this skill just opens that viewer in headless Chromium and element-screenshots the slide `<canvas>`. The result is a clean 16:9 image of the title slide with no viewer chrome.

## What it does

```bash
uv run .agents/skills/thumbnail-of-pptx/thumbnail_of_pptx.py <url> <output_path>
```

- `url`: OneDrive sharing link or an `aka.ms` short link that redirects to one
- `output_path`: where to write the PNG
- `--slide N` (default 1): which slide to capture
- `--scale N` (default 2): device scale factor for crispness
- `--wait MS` (default 9000): render wait

Locates the viewer iframe (`wacIframe`, with a `<canvas>`-based fallback), optionally advances to slide N via arrow keys, then screenshots the canvas.

## Complementary to fetch-slides

- `fetch-slides` → full deck as a PDF (needs LibreOffice for PPTX)
- `thumbnail-of-pptx` → one lightweight slide image, works even when the file isn't downloadable

## Notes

- Prerequisite: `uv run playwright install chromium`
- Tested end-to-end against a real OneDrive-hosted deck; produced a clean title-slide thumbnail.
- README updated with the skill entry and both `npx skills` / `gh skill install` command lists.