### PR TITLE
Add MAI image generation skill

### DIFF
--- a/.agents/skills/generate-images-mai/SKILL.md
+++ b/.agents/skills/generate-images-mai/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: generate-images-mai
+description: 'Generate bitmap images from text prompts with Microsoft MAI-Image-2.5 through the Azure AI image generations API. Use when asked to create, render, illustrate, or generate an image, visual asset, photograph, background, poster, thumbnail, or concept art with Microsoft Image 2.5 or MAI-Image-2.5.'
+argument-hint: 'Describe the image and optionally provide output path, width, and height'
+user-invocable: true
+disable-model-invocation: false
+---
+
+# Generate images with MAI-Image-2.5
+
+Create an image from a text description, save it to the user's requested location, and verify that the resulting file is usable.
+
+## Requirements
+
+Use a `.env` file in the current directory or one of its parents:
+
+```dotenv
+AZURE_API_KEY=your-key
+AZURE_IMAGE_ENDPOINT=https://your-resource.services.ai.azure.com/mai/v1/images/generations
+```
+
+Never read, print, return, commit, or embed the API key in generated files, commands, logs, or chat. Do not create a `.env` containing a real secret. If configuration is missing, tell the user which variable to add without asking them to send its value through chat.
+
+## Procedure
+
+1. Determine the requested subject, intended use, output path, dimensions, and visual constraints from the conversation.
+2. If the prompt is underspecified, preserve the user's intent and add only useful visual detail: medium, composition, environment, lighting, palette, camera or rendering style, and important exclusions. Do not introduce brands, people, text, or sensitive attributes the user did not request.
+3. Default to `1024x1024` and `generated_image.png` when dimensions or output path are absent. Use the user's requested dimensions without inventing API restrictions.
+4. Run [generate_image.py](./scripts/generate_image.py) with the refined prompt. Pass arguments as separate shell tokens and quote all user-provided values.
+
+```bash
+python3 .agents/skills/generate-images-mai/scripts/generate_image.py \
+  --prompt "A photograph of a red fox in an autumn forest" \
+  --width 1024 \
+  --height 1024 \
+  --output generated_image.png
+```
+
+5. If the destination exists, do not overwrite it unless the user explicitly requested replacement; use a new descriptive filename or pass `--force` only with that permission.
+6. Verify the output exists, is non-empty, and can be decoded as an image. Use the image-viewing tool to inspect it when available.
+7. Check that the result matches the requested subject, composition, dimensions, legibility, and safety constraints. Regenerate with a targeted prompt adjustment when the image is blank, malformed, materially off-topic, or has obvious layout defects.
+8. Report the saved path and final dimensions. Mention prompt changes only when they materially affect the user's request.
+
+## Options
+
+The script supports:
+
+- `--prompt`: required image description.
+- `--output`: output file path; defaults to `generated_image.png`.
+- `--width` and `--height`: positive integers; default to `1024`.
+- `--model`: model name; defaults to `MAI-Image-2.5`.
+- `--endpoint`: overrides `AZURE_IMAGE_ENDPOINT` for this invocation.
+- `--env-file`: loads a specific `.env` file instead of searching parent directories.
+- `--force`: permits replacing an existing output file.
+
+Environment variables already present in the process take precedence over values in `.env`.
+
+## Failure handling
+
+- Missing configuration: identify the missing variable and stop.
+- HTTP authentication failure: tell the user to verify `AZURE_API_KEY` locally; never request the key in chat.
+- HTTP endpoint or deployment failure: report the status and sanitized API message, then verify the endpoint and model name.
+- Invalid or absent `b64_json`: do not create an output file; report the response-shape problem.
+- Content-policy rejection: explain that the service rejected the prompt and offer a compliant revision.
+- Corrupt or empty image: remove the incomplete output and retry once with the same request before changing the prompt.
+
+## Completion checks
+
+- The secret was not exposed.
+- The requested output was created without overwriting unrelated work.
+- The file is a decodable image with the requested dimensions.
+- Visual inspection confirms the primary subject and layout are present.
+- The user receives a clickable path to the image.

--- a/.agents/skills/generate-images-mai/SKILL.md
+++ b/.agents/skills/generate-images-mai/SKILL.md
@@ -49,7 +49,7 @@ The script supports:
 - `--output`: output file path; defaults to `generated_image.png`.
 - `--width` and `--height`: positive integers; default to `1024`.
 - `--model`: model name; defaults to `MAI-Image-2.5`.
-- `--endpoint`: overrides `AZURE_IMAGE_ENDPOINT` for this invocation.
+- `--endpoint`: Azure image generations endpoint; overrides `AZURE_IMAGE_ENDPOINT`.
 - `--env-file`: loads a specific `.env` file instead of searching parent directories.
 - `--force`: permits replacing an existing output file.
 
@@ -57,7 +57,7 @@ Environment variables already present in the process take precedence over values
 
 ## Failure handling
 
-- Missing configuration: identify the missing variable and stop.
+- Missing configuration: identify `AZURE_API_KEY` or `AZURE_IMAGE_ENDPOINT` and stop.
 - HTTP authentication failure: tell the user to verify `AZURE_API_KEY` locally; never request the key in chat.
 - HTTP endpoint or deployment failure: report the status and sanitized API message, then verify the endpoint and model name.
 - Invalid or absent `b64_json`: do not create an output file; report the response-shape problem.

--- a/.agents/skills/generate-images-mai/SKILL.md
+++ b/.agents/skills/generate-images-mai/SKILL.md
@@ -12,8 +12,8 @@ Create an image from a text description, save it to the user's requested locatio
 
 ## Requirements
 
-Use a `.env` file in the current directory or one of its parents:
-
+- Python 3.10+.
+- A `.env` file in the current directory or one of its parents:
 ```dotenv
 AZURE_API_KEY=your-key
 AZURE_IMAGE_ENDPOINT=https://your-resource.services.ai.azure.com/mai/v1/images/generations

--- a/.agents/skills/generate-images-mai/scripts/generate_image.py
+++ b/.agents/skills/generate-images-mai/scripts/generate_image.py
@@ -1,4 +1,12 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Generate an image with Microsoft MAI-Image-2.5 via the Azure AI image generations API.
+
+Requires AZURE_API_KEY and AZURE_IMAGE_ENDPOINT (or pass --endpoint).
+"""
 
 import argparse
 import base64
@@ -8,8 +16,6 @@ import sys
 from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
-
-
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Generate an image with Microsoft MAI-Image-2.5."

--- a/.agents/skills/generate-images-mai/scripts/generate_image.py
+++ b/.agents/skills/generate-images-mai/scripts/generate_image.py
@@ -10,9 +10,6 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 
-DEFAULT_ENDPOINT = "https://model-releases-proj-resource.services.ai.azure.com/mai/v1/images/generations"
-
-
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Generate an image with Microsoft MAI-Image-2.5."
@@ -22,7 +19,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--width", type=positive_int, default=1024)
     parser.add_argument("--height", type=positive_int, default=1024)
     parser.add_argument("--model", default="MAI-Image-2.5")
-    parser.add_argument("--endpoint", help="Override AZURE_IMAGE_ENDPOINT")
+    parser.add_argument("--endpoint", help="Azure image generations endpoint")
     parser.add_argument("--env-file", type=Path, help="Path to a specific .env file")
     parser.add_argument("--force", action="store_true", help="Overwrite the output file")
     return parser.parse_args()
@@ -91,7 +88,15 @@ def main() -> int:
         print("Missing AZURE_API_KEY. Add it to your environment or .env file.", file=sys.stderr)
         return 2
 
-    endpoint = args.endpoint or os.environ.get("AZURE_IMAGE_ENDPOINT") or DEFAULT_ENDPOINT
+    endpoint = args.endpoint or os.environ.get("AZURE_IMAGE_ENDPOINT")
+    if not endpoint:
+        print(
+            "Missing AZURE_IMAGE_ENDPOINT. Add it to your environment or .env file, "
+            "or pass --endpoint.",
+            file=sys.stderr,
+        )
+        return 2
+
     output = args.output.expanduser().resolve()
     if output.exists() and not args.force:
         print(f"Output already exists: {output}. Use --force to replace it.", file=sys.stderr)

--- a/.agents/skills/generate-images-mai/scripts/generate_image.py
+++ b/.agents/skills/generate-images-mai/scripts/generate_image.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+
+import argparse
+import base64
+import json
+import os
+import sys
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+DEFAULT_ENDPOINT = "https://model-releases-proj-resource.services.ai.azure.com/mai/v1/images/generations"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate an image with Microsoft MAI-Image-2.5."
+    )
+    parser.add_argument("--prompt", required=True, help="Text description of the image")
+    parser.add_argument("--output", type=Path, default=Path("generated_image.png"))
+    parser.add_argument("--width", type=positive_int, default=1024)
+    parser.add_argument("--height", type=positive_int, default=1024)
+    parser.add_argument("--model", default="MAI-Image-2.5")
+    parser.add_argument("--endpoint", help="Override AZURE_IMAGE_ENDPOINT")
+    parser.add_argument("--env-file", type=Path, help="Path to a specific .env file")
+    parser.add_argument("--force", action="store_true", help="Overwrite the output file")
+    return parser.parse_args()
+
+
+def positive_int(value: str) -> int:
+    number = int(value)
+    if number <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return number
+
+
+def find_env_file(start: Path) -> Path | None:
+    for directory in (start, *start.parents):
+        candidate = directory / ".env"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def load_env_file(path: Path) -> None:
+    for line_number, raw_line in enumerate(path.read_text().splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[7:].lstrip()
+        if "=" not in line:
+            raise ValueError(f"Invalid .env entry at {path}:{line_number}")
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+            value = value[1:-1]
+        if key:
+            os.environ.setdefault(key, value)
+
+
+def sanitized_api_error(error: HTTPError) -> str:
+    body = error.read().decode("utf-8", errors="replace")
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        return body[:500].strip() or error.reason
+
+    if isinstance(payload, dict):
+        detail = payload.get("error", payload)
+        if isinstance(detail, dict):
+            return str(detail.get("message") or detail.get("code") or "Request failed")
+        return str(detail)
+    return "Request failed"
+
+
+def main() -> int:
+    args = parse_args()
+    env_file = args.env_file or find_env_file(Path.cwd())
+    if env_file:
+        try:
+            load_env_file(env_file.expanduser().resolve())
+        except (OSError, ValueError) as error:
+            print(f"Configuration error: {error}", file=sys.stderr)
+            return 2
+
+    api_key = os.environ.get("AZURE_API_KEY")
+    if not api_key:
+        print("Missing AZURE_API_KEY. Add it to your environment or .env file.", file=sys.stderr)
+        return 2
+
+    endpoint = args.endpoint or os.environ.get("AZURE_IMAGE_ENDPOINT") or DEFAULT_ENDPOINT
+    output = args.output.expanduser().resolve()
+    if output.exists() and not args.force:
+        print(f"Output already exists: {output}. Use --force to replace it.", file=sys.stderr)
+        return 2
+
+    request_body = json.dumps(
+        {
+            "prompt": args.prompt,
+            "width": args.width,
+            "height": args.height,
+            "model": args.model,
+        }
+    ).encode("utf-8")
+    request = Request(
+        endpoint,
+        data=request_body,
+        headers={"Content-Type": "application/json", "api-key": api_key},
+        method="POST",
+    )
+
+    try:
+        with urlopen(request, timeout=180) as response:
+            payload = json.load(response)
+    except HTTPError as error:
+        print(
+            f"Image API returned HTTP {error.code}: {sanitized_api_error(error)}",
+            file=sys.stderr,
+        )
+        return 1
+    except (URLError, TimeoutError, json.JSONDecodeError) as error:
+        print(f"Image request failed: {error}", file=sys.stderr)
+        return 1
+
+    try:
+        encoded_image = payload["data"][0]["b64_json"]
+        image_bytes = base64.b64decode(encoded_image, validate=True)
+    except (KeyError, IndexError, TypeError, ValueError) as error:
+        print(f"Image API response did not contain valid b64_json: {error}", file=sys.stderr)
+        return 1
+
+    if not image_bytes:
+        print("Image API returned an empty image.", file=sys.stderr)
+        return 1
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary_output = output.with_name(f".{output.name}.tmp")
+    try:
+        temporary_output.write_bytes(image_bytes)
+        temporary_output.replace(output)
+    except OSError as error:
+        temporary_output.unlink(missing_ok=True)
+        print(f"Could not write output image: {error}", file=sys.stderr)
+        return 1
+
+    print(f"Generated image: {output}")
+    print(f"Requested dimensions: {args.width}x{args.height}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ Downloads live chat messages from YouTube videos using yt-dlp. Supports output w
 
 **Use when:** fetching live chat or chat replay from a YouTube live stream or past stream.
 
+### 🎨 generate-images-mai
+
+Generates bitmap images from text prompts with Microsoft MAI-Image-2.5 through the Azure AI image generations API.
+
+**Use when:** creating an image, visual asset, photograph, background, poster, thumbnail, or concept art.
+
 ### 🗣️ discussion-commenter
 
 Posts Q&A entries from markdown writeups as individual comments to a GitHub Discussion. Each `## ` section in the writeup becomes a separate comment, prefixed with a date.
@@ -106,6 +112,7 @@ npx skills add pamelafox/presentation-skills/fetch-slides
 npx skills add pamelafox/presentation-skills/outline-slides
 npx skills add pamelafox/presentation-skills/generate-writeup
 npx skills add pamelafox/presentation-skills/youtube-live-chat
+npx skills add pamelafox/presentation-skills/generate-images-mai
 npx skills add pamelafox/presentation-skills/discussion-commenter
 ```
 
@@ -131,6 +138,7 @@ gh skill install pamelafox/presentation-skills fetch-slides
 gh skill install pamelafox/presentation-skills outline-slides
 gh skill install pamelafox/presentation-skills generate-writeup
 gh skill install pamelafox/presentation-skills youtube-live-chat
+gh skill install pamelafox/presentation-skills generate-images-mai
 gh skill install pamelafox/presentation-skills discussion-commenter
 ```
 


### PR DESCRIPTION
## Summary

- add the `generate-images-mai` skill for Microsoft MAI-Image-2.5
- include a standard-library Python script for the Azure AI image generations API
- document the skill and its `npx skills` and `gh skill` installation commands

## Validation

- `python3 -m py_compile .agents/skills/generate-images-mai/scripts/generate_image.py`
- `python3 .agents/skills/generate-images-mai/scripts/generate_image.py --help`
- `git diff --cached --check`
- verified the new skill contains no `.env`, bytecode, or stale `generate-images-mai-2-5` references