### PR TITLE
Add image editing support to MAI image skill

### DIFF
--- a/.agents/skills/generate-images-mai/SKILL.md
+++ b/.agents/skills/generate-images-mai/SKILL.md
@@ -1,32 +1,38 @@
 ---
 name: generate-images-mai
-description: 'Generate bitmap images from text prompts with Microsoft MAI-Image-2.5 through the Azure AI image generations API. Use when asked to create, render, illustrate, or generate an image, visual asset, photograph, background, poster, thumbnail, or concept art with Microsoft Image 2.5 or MAI-Image-2.5.'
-argument-hint: 'Describe the image and optionally provide output path, width, and height'
+description: 'Generate or edit bitmap images with Microsoft MAI-Image-2.5 through the Azure AI image APIs. Use for text-to-image generation, image-to-image edits, object removal or replacement, inpainting, text updates, artifact cleanup, reference-image transformations, posters, thumbnails, and concept art.'
+argument-hint: 'Describe the image or edit and optionally provide an input image, output path, width, and height'
 user-invocable: true
 disable-model-invocation: false
 ---
 
-# Generate images with MAI-Image-2.5
+# Generate and edit images with MAI-Image-2.5
 
-Create an image from a text description, save it to the user's requested location, and verify that the resulting file is usable.
+Create an image from text or edit a supplied JPEG or PNG, save the result, and verify that the output is usable.
 
 ## Requirements
 
 - Python 3.10+.
 - A `.env` file in the current directory or one of its parents:
+
 ```dotenv
 AZURE_API_KEY=your-key
 AZURE_IMAGE_ENDPOINT=https://your-resource.services.ai.azure.com/mai/v1/images/generations
 ```
 
+The endpoint can be the resource root, `/mai/v1/images`, `/generations`, or `/edits`; the script selects the operation-specific path.
+
 Never read, print, return, commit, or embed the API key in generated files, commands, logs, or chat. Do not create a `.env` containing a real secret. If configuration is missing, tell the user which variable to add without asking them to send its value through chat.
 
 ## Procedure
 
-1. Determine the requested subject, intended use, output path, dimensions, and visual constraints from the conversation.
-2. If the prompt is underspecified, preserve the user's intent and add only useful visual detail: medium, composition, environment, lighting, palette, camera or rendering style, and important exclusions. Do not introduce brands, people, text, or sensitive attributes the user did not request.
-3. Default to `1024x1024` and `generated_image.png` when dimensions or output path are absent. Use the user's requested dimensions without inventing API restrictions.
-4. Run [generate_image.py](./scripts/generate_image.py) with the refined prompt. Pass arguments as separate shell tokens and quote all user-provided values.
+1. Determine the requested subject or edit, intended use, output path, dimensions, and visual constraints from the conversation.
+2. For an edit, confirm that the input is a readable JPEG or PNG. Preserve the original composition or identity unless the request says otherwise.
+3. If the prompt is underspecified, preserve the user's intent and add only useful visual detail: medium, composition, environment, lighting, palette, camera or rendering style, and important exclusions. Do not introduce brands, people, text, or sensitive attributes the user did not request.
+4. Default to `1024x1024` and `generated_image.png` for generation. Generation dimensions must each be at least 768 pixels and contain no more than 1,048,576 total pixels. Edit output is always PNG and dimensions are controlled by the service.
+5. Run [generate_image.py](./scripts/generate_image.py) with the refined prompt. Pass arguments as separate shell tokens and quote all user-provided values.
+
+Text-to-image generation:
 
 ```bash
 python3 .agents/skills/generate-images-mai/scripts/generate_image.py \
@@ -36,38 +42,58 @@ python3 .agents/skills/generate-images-mai/scripts/generate_image.py \
   --output generated_image.png
 ```
 
-5. If the destination exists, do not overwrite it unless the user explicitly requested replacement; use a new descriptive filename or pass `--force` only with that permission.
-6. Verify the output exists, is non-empty, and can be decoded as an image. Use the image-viewing tool to inspect it when available.
-7. Check that the result matches the requested subject, composition, dimensions, legibility, and safety constraints. Regenerate with a targeted prompt adjustment when the image is blank, malformed, materially off-topic, or has obvious layout defects.
-8. Report the saved path and final dimensions. Mention prompt changes only when they materially affect the user's request.
+Image-to-image edit:
+
+```bash
+python3 .agents/skills/generate-images-mai/scripts/generate_image.py \
+  --prompt "Replace the lawn with a native wildflower garden while preserving the house and paths" \
+  --input-image garden.png \
+  --output edited_garden.png
+```
+
+6. If the destination exists, do not overwrite it unless the user explicitly requested replacement; use a new descriptive filename or pass `--force` only with that permission.
+7. Verify the output exists, is non-empty, and can be decoded as an image. Use the image-viewing tool to inspect it when available.
+8. Check that the result matches the requested subject or edit, composition, legibility, and safety constraints. Regenerate with a targeted prompt adjustment when the image is blank, malformed, materially off-topic, or has obvious layout defects.
+9. Report the saved path and, when available, final dimensions. Mention prompt changes only when they materially affect the user's request.
 
 ## Options
 
-The script supports:
-
-- `--prompt`: required image description.
-- `--output`: output file path; defaults to `generated_image.png`.
-- `--width` and `--height`: positive integers; default to `1024`.
-- `--model`: model name; defaults to `MAI-Image-2.5`.
-- `--endpoint`: Azure image generations endpoint; overrides `AZURE_IMAGE_ENDPOINT`.
-- `--env-file`: loads a specific `.env` file instead of searching parent directories.
-- `--force`: permits replacing an existing output file.
+- `--prompt`: Required image description or editing instruction.
+- `--input-image`: Optional JPEG or PNG image to edit. When present, the script uses the MAI image edits API.
+- `--output`: Output PNG path; defaults to `generated_image.png`.
+- `--width` and `--height`: Generation dimensions; each defaults to `1024`. Ignored for edits.
+- `--model`: Deployment name; defaults to `MAI-Image-2.5`.
+- `--endpoint`: Azure resource or image API endpoint; overrides `AZURE_IMAGE_ENDPOINT`.
+- `--env-file`: Loads a specific `.env` file instead of searching parent directories.
+- `--force`: Permits replacing an existing output file.
 
 Environment variables already present in the process take precedence over values in `.env`.
 
+## API behavior
+
+- Text generation sends JSON to `/mai/v1/images/generations`.
+- Image editing sends `prompt`, `model`, and one `image` as multipart form data to `/mai/v1/images/edits`.
+- Image edits accept JPEG or PNG input and return PNG output.
+- MAI-Image-2.5 image editing is currently a public-preview feature and isn't recommended for production workloads without accounting for preview limitations.
+
 ## Failure handling
 
-- Missing configuration: identify `AZURE_API_KEY` or `AZURE_IMAGE_ENDPOINT` and stop.
-- HTTP authentication failure: tell the user to verify `AZURE_API_KEY` locally; never request the key in chat.
-- HTTP endpoint or deployment failure: report the status and sanitized API message, then verify the endpoint and model name.
-- Invalid or absent `b64_json`: do not create an output file; report the response-shape problem.
-- Content-policy rejection: explain that the service rejected the prompt and offer a compliant revision.
-- Corrupt or empty image: remove the incomplete output and retry once with the same request before changing the prompt.
+- Missing configuration: Identify `AZURE_API_KEY` or `AZURE_IMAGE_ENDPOINT` and stop.
+- Invalid input image: Report that image edits require a readable JPEG or PNG.
+- HTTP authentication failure: Tell the user to verify `AZURE_API_KEY` locally; never request the key in chat.
+- HTTP endpoint or deployment failure: Report the status and sanitized API message, then verify the endpoint and deployment name.
+- Invalid or absent `b64_json`: Do not create an output file; report the response-shape problem.
+- Content-policy rejection: Explain that the service rejected the prompt and offer a compliant revision.
+- Corrupt or empty image: Remove the incomplete output and retry once with the same request before changing the prompt.
 
 ## Completion checks
 
 - The secret was not exposed.
 - The requested output was created without overwriting unrelated work.
-- The file is a decodable image with the requested dimensions.
-- Visual inspection confirms the primary subject and layout are present.
+- The file is a decodable image.
+- Visual inspection confirms the primary subject and requested edits are present.
 - The user receives a clickable path to the image.
+
+## Reference
+
+- [Deploy and use MAI image models in Microsoft Foundry](https://learn.microsoft.com/azure/foundry/foundry-models/how-to/use-foundry-models-mai-image)

--- a/.agents/skills/generate-images-mai/scripts/generate_image.py
+++ b/.agents/skills/generate-images-mai/scripts/generate_image.py
@@ -3,7 +3,7 @@
 # requires-python = ">=3.10"
 # dependencies = []
 # ///
-"""Generate an image with Microsoft MAI-Image-2.5 via the Azure AI image generations API.
+"""Generate or edit an image with Microsoft MAI-Image-2.5.
 
 Requires AZURE_API_KEY and AZURE_IMAGE_ENDPOINT (or pass --endpoint).
 """
@@ -13,22 +13,10 @@ import base64
 import json
 import os
 import sys
+import uuid
 from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Generate an image with Microsoft MAI-Image-2.5."
-    )
-    parser.add_argument("--prompt", required=True, help="Text description of the image")
-    parser.add_argument("--output", type=Path, default=Path("generated_image.png"))
-    parser.add_argument("--width", type=positive_int, default=1024)
-    parser.add_argument("--height", type=positive_int, default=1024)
-    parser.add_argument("--model", default="MAI-Image-2.5")
-    parser.add_argument("--endpoint", help="Azure image generations endpoint")
-    parser.add_argument("--env-file", type=Path, help="Path to a specific .env file")
-    parser.add_argument("--force", action="store_true", help="Overwrite the output file")
-    return parser.parse_args()
 
 
 def positive_int(value: str) -> int:
@@ -36,6 +24,26 @@ def positive_int(value: str) -> int:
     if number <= 0:
         raise argparse.ArgumentTypeError("must be a positive integer")
     return number
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate or edit an image with Microsoft MAI-Image-2.5."
+    )
+    parser.add_argument("--prompt", required=True, help="Image description or edit instruction")
+    parser.add_argument(
+        "--input-image",
+        type=Path,
+        help="JPEG or PNG image to edit; omit for text-to-image generation",
+    )
+    parser.add_argument("--output", type=Path, default=Path("generated_image.png"))
+    parser.add_argument("--width", type=positive_int, default=1024)
+    parser.add_argument("--height", type=positive_int, default=1024)
+    parser.add_argument("--model", default="MAI-Image-2.5")
+    parser.add_argument("--endpoint", help="Azure resource or MAI image API endpoint")
+    parser.add_argument("--env-file", type=Path, help="Path to a specific .env file")
+    parser.add_argument("--force", action="store_true", help="Overwrite the output file")
+    return parser.parse_args(argv)
 
 
 def find_env_file(start: Path) -> Path | None:
@@ -64,6 +72,61 @@ def load_env_file(path: Path) -> None:
             os.environ.setdefault(key, value)
 
 
+def operation_endpoint(configured_endpoint: str, editing: bool) -> str:
+    endpoint = configured_endpoint.rstrip("/")
+    operation = "edits" if editing else "generations"
+    for suffix in ("/generations", "/edits"):
+        if endpoint.endswith(suffix):
+            return f"{endpoint.removesuffix(suffix)}/{operation}"
+    if endpoint.endswith("/mai/v1/images"):
+        return f"{endpoint}/{operation}"
+    if endpoint.endswith(".azure.com"):
+        return f"{endpoint}/mai/v1/images/{operation}"
+    return endpoint
+
+
+def image_media_type(path: Path, image_bytes: bytes) -> str:
+    if image_bytes.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if image_bytes.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    raise ValueError(f"Input image must be a JPEG or PNG: {path}")
+
+
+def multipart_body(
+    prompt: str,
+    model: str,
+    image_path: Path,
+    image_bytes: bytes,
+    media_type: str,
+) -> tuple[bytes, str]:
+    boundary = f"----mai-image-{uuid.uuid4().hex}"
+    chunks: list[bytes] = []
+
+    for name, value in (("prompt", prompt), ("model", model)):
+        chunks.extend(
+            (
+                f"--{boundary}\r\n".encode(),
+                f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode(),
+                value.encode("utf-8"),
+                b"\r\n",
+            )
+        )
+
+    filename = image_path.name.replace('"', "")
+    chunks.extend(
+        (
+            f"--{boundary}\r\n".encode(),
+            f'Content-Disposition: form-data; name="image"; filename="{filename}"\r\n'.encode(),
+            f"Content-Type: {media_type}\r\n\r\n".encode(),
+            image_bytes,
+            b"\r\n",
+            f"--{boundary}--\r\n".encode(),
+        )
+    )
+    return b"".join(chunks), f"multipart/form-data; boundary={boundary}"
+
+
 def sanitized_api_error(error: HTTPError) -> str:
     body = error.read().decode("utf-8", errors="replace")
     try:
@@ -79,8 +142,8 @@ def sanitized_api_error(error: HTTPError) -> str:
     return "Request failed"
 
 
-def main() -> int:
-    args = parse_args()
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
     env_file = args.env_file or find_env_file(Path.cwd())
     if env_file:
         try:
@@ -94,8 +157,8 @@ def main() -> int:
         print("Missing AZURE_API_KEY. Add it to your environment or .env file.", file=sys.stderr)
         return 2
 
-    endpoint = args.endpoint or os.environ.get("AZURE_IMAGE_ENDPOINT")
-    if not endpoint:
+    configured_endpoint = args.endpoint or os.environ.get("AZURE_IMAGE_ENDPOINT")
+    if not configured_endpoint:
         print(
             "Missing AZURE_IMAGE_ENDPOINT. Add it to your environment or .env file, "
             "or pass --endpoint.",
@@ -108,18 +171,41 @@ def main() -> int:
         print(f"Output already exists: {output}. Use --force to replace it.", file=sys.stderr)
         return 2
 
-    request_body = json.dumps(
-        {
-            "prompt": args.prompt,
-            "width": args.width,
-            "height": args.height,
-            "model": args.model,
-        }
-    ).encode("utf-8")
+    editing = args.input_image is not None
+    endpoint = operation_endpoint(configured_endpoint, editing)
+
+    if editing:
+        input_image = args.input_image.expanduser().resolve()
+        try:
+            input_bytes = input_image.read_bytes()
+            media_type = image_media_type(input_image, input_bytes)
+        except (OSError, ValueError) as error:
+            print(f"Invalid input image: {error}", file=sys.stderr)
+            return 2
+        request_body, content_type = multipart_body(
+            args.prompt, args.model, input_image, input_bytes, media_type
+        )
+    else:
+        if args.width < 768 or args.height < 768:
+            print("Generation width and height must each be at least 768.", file=sys.stderr)
+            return 2
+        if args.width * args.height > 1_048_576:
+            print("Generation width x height must not exceed 1,048,576 pixels.", file=sys.stderr)
+            return 2
+        request_body = json.dumps(
+            {
+                "prompt": args.prompt,
+                "width": args.width,
+                "height": args.height,
+                "model": args.model,
+            }
+        ).encode("utf-8")
+        content_type = "application/json"
+
     request = Request(
         endpoint,
         data=request_body,
-        headers={"Content-Type": "application/json", "api-key": api_key},
+        headers={"Content-Type": content_type, "api-key": api_key},
         method="POST",
     )
 
@@ -157,8 +243,10 @@ def main() -> int:
         print(f"Could not write output image: {error}", file=sys.stderr)
         return 1
 
-    print(f"Generated image: {output}")
-    print(f"Requested dimensions: {args.width}x{args.height}")
+    action = "Edited" if editing else "Generated"
+    print(f"{action} image: {output}")
+    if not editing:
+        print(f"Requested dimensions: {args.width}x{args.height}")
     return 0
 
 

--- a/.agents/skills/generate-images-mai/scripts/test_generate_image.py
+++ b/.agents/skills/generate-images-mai/scripts/test_generate_image.py
@@ -1,0 +1,135 @@
+import base64
+import importlib.util
+import io
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT_PATH = Path(__file__).with_name("generate_image.py")
+SPEC = importlib.util.spec_from_file_location("generate_image", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+generate_image = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(generate_image)
+
+
+class FakeResponse(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+
+class GenerateImageTests(unittest.TestCase):
+    def api_response(self) -> FakeResponse:
+        image = base64.b64encode(b"result-image").decode()
+        return FakeResponse(json.dumps({"data": [{"b64_json": image}]}).encode())
+
+    def test_generation_uses_json_generations_endpoint(self):
+        captured = {}
+
+        def fake_urlopen(request, timeout):
+            captured["request"] = request
+            captured["timeout"] = timeout
+            return self.api_response()
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output = Path(temporary_directory) / "generated.png"
+            environment = {
+                "AZURE_API_KEY": "test-key",
+                "AZURE_IMAGE_ENDPOINT": "https://example.services.ai.azure.com/mai/v1/images/edits",
+            }
+            with patch.dict(os.environ, environment, clear=True), patch.object(
+                generate_image, "urlopen", fake_urlopen
+            ):
+                result = generate_image.main(["--prompt", "A garden", "--output", str(output)])
+
+            self.assertEqual(result, 0)
+            self.assertEqual(
+                captured["request"].full_url,
+                "https://example.services.ai.azure.com/mai/v1/images/generations",
+            )
+            self.assertEqual(captured["request"].get_header("Content-type"), "application/json")
+            self.assertEqual(json.loads(captured["request"].data)["prompt"], "A garden")
+            self.assertEqual(output.read_bytes(), b"result-image")
+
+    def test_edit_uses_multipart_edits_endpoint(self):
+        captured = {}
+
+        def fake_urlopen(request, timeout):
+            captured["request"] = request
+            return self.api_response()
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            directory = Path(temporary_directory)
+            input_image = directory / "garden.png"
+            input_image.write_bytes(b"\x89PNG\r\n\x1a\nsource-image")
+            output = directory / "edited.png"
+            environment = {
+                "AZURE_API_KEY": "test-key",
+                "AZURE_IMAGE_ENDPOINT": "https://example.services.ai.azure.com/mai/v1/images/generations",
+            }
+            with patch.dict(os.environ, environment, clear=True), patch.object(
+                generate_image, "urlopen", fake_urlopen
+            ):
+                result = generate_image.main(
+                    [
+                        "--prompt",
+                        "Add native flowers",
+                        "--input-image",
+                        str(input_image),
+                        "--output",
+                        str(output),
+                    ]
+                )
+
+            request = captured["request"]
+            self.assertEqual(result, 0)
+            self.assertEqual(
+                request.full_url,
+                "https://example.services.ai.azure.com/mai/v1/images/edits",
+            )
+            self.assertTrue(request.get_header("Content-type").startswith("multipart/form-data; boundary="))
+            self.assertIn(b'name="prompt"', request.data)
+            self.assertIn(b"Add native flowers", request.data)
+            self.assertIn(b'name="model"', request.data)
+            self.assertIn(b'name="image"; filename="garden.png"', request.data)
+            self.assertIn(b"Content-Type: image/png", request.data)
+            self.assertIn(b"source-image", request.data)
+            self.assertEqual(output.read_bytes(), b"result-image")
+
+    def test_edit_rejects_unsupported_input_before_request(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            directory = Path(temporary_directory)
+            input_image = directory / "garden.gif"
+            input_image.write_bytes(b"GIF89a")
+            output = directory / "edited.png"
+            environment = {
+                "AZURE_API_KEY": "test-key",
+                "AZURE_IMAGE_ENDPOINT": "https://example.services.ai.azure.com/mai/v1/images/generations",
+            }
+            with patch.dict(os.environ, environment, clear=True), patch.object(
+                generate_image, "urlopen"
+            ) as mocked_urlopen:
+                result = generate_image.main(
+                    [
+                        "--prompt",
+                        "Add flowers",
+                        "--input-image",
+                        str(input_image),
+                        "--output",
+                        str(output),
+                    ]
+                )
+
+            self.assertEqual(result, 2)
+            mocked_urlopen.assert_not_called()
+            self.assertFalse(output.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add image-to-image editing through the MAI `/images/edits` API
- accept JPEG and PNG inputs with a new `--input-image` option
- build multipart requests using only the Python standard library
- normalize resource, images, generations, and edits endpoint forms automatically
- preserve the existing text-to-image generation workflow
- document edit usage, format constraints, and preview status
- add focused tests for generation, editing, and unsupported input rejection

## Validation

- `python3 .agents/skills/generate-images-mai/scripts/test_generate_image.py` (3 tests pass)
- `python3 -m py_compile .agents/skills/generate-images-mai/scripts/generate_image.py .agents/skills/generate-images-mai/scripts/test_generate_image.py`
- VS Code diagnostics: no errors in the skill documentation, script, or tests
- exercised the edit path against a deployed `MAI-Image-2.5-Pro` model with PNG input and output